### PR TITLE
[picta/feat] Add output Object that is Sendable and Codable

### DIFF
--- a/Sources/Spyder/API+Invoking.swift
+++ b/Sources/Spyder/API+Invoking.swift
@@ -6,13 +6,12 @@ import FoundationNetworking
 // MARK: API invoking functions
 
 extension API {
-  public func invokeAndForget<Input>(request: Input) async throws
-  where Input: URLRequestBuilder {
+  public func invokeAndForget(request: URLRequestBuilder) async throws {
     let urlRequest = try request.urlRequest(for: self)
     try await invokeWithCacheCheck(urlRequest)
   }
-  public func invokeWaitingResponse<Input, Output>(request: Input) async throws -> Output
-  where Input: URLRequestBuilder, Output: Decodable {
+
+  public func invokeWaitingResponse<Output>(request: URLRequestBuilder) async throws -> Output where Output: Object {
     let urlRequest = try request.urlRequest(for: self)
     let responseData = try await invokeWithCacheCheck(urlRequest)
     return try decodeResponseData(responseData, from: urlRequest)
@@ -31,6 +30,7 @@ extension API {
     }
     return cachedResponseData
   }
+
   private func invokeUsingInvoker(_ urlRequest: URLRequest) async throws -> HTTPResponse {
     do {
       var response = try await invoker(urlRequest)
@@ -47,8 +47,8 @@ extension API {
       throw error
     }
   }
-  private func decodeResponseData<Output>(_ data: Data, from urlRequest: URLRequest) throws -> Output
-  where Output: Decodable {
+
+  private func decodeResponseData<Output: Object>(_ data: Data, from urlRequest: URLRequest) throws -> Output {
     do {
       return try jsonDecoder.decode(Output.self, from: data)
     } catch {
@@ -79,6 +79,7 @@ public enum Invoker {
     )
   }
 }
+
 extension Invoker {
   enum DefaultHTTPInvokerError: Swift.Error {
     case missingHTTPResponse

--- a/Sources/Spyder/API+Invoking.swift
+++ b/Sources/Spyder/API+Invoking.swift
@@ -11,7 +11,7 @@ extension API {
     try await invokeWithCacheCheck(urlRequest)
   }
 
-  public func invokeWaitingResponse<Output>(request: URLRequestBuilder) async throws -> Output where Output: Object {
+  public func invokeWaitingResponse<Output: Response>(request: URLRequestBuilder) async throws -> Output {
     let urlRequest = try request.urlRequest(for: self)
     let responseData = try await invokeWithCacheCheck(urlRequest)
     return try decodeResponseData(responseData, from: urlRequest)
@@ -48,7 +48,7 @@ extension API {
     }
   }
 
-  private func decodeResponseData<Output: Object>(_ data: Data, from urlRequest: URLRequest) throws -> Output {
+  private func decodeResponseData<Output: Response>(_ data: Data, from urlRequest: URLRequest) throws -> Output {
     do {
       return try jsonDecoder.decode(Output.self, from: data)
     } catch {

--- a/Sources/Spyder/API+Logging.swift
+++ b/Sources/Spyder/API+Logging.swift
@@ -15,6 +15,7 @@ extension API {
       ].joined(separator: ", ")
     )
   }
+
   internal func logResponse(for urlRequest: URLRequest, response: HTTPResponse) {
     let isSuccess = (200...299).contains(response.statusCode)
     logNetworkingEvent(
@@ -22,6 +23,7 @@ extension API {
       message: "\(isSuccess ? "✅ success" : "❌ failure")[\(response.statusCode)]"
     )
   }
+
   internal func logInvocationFailure(for urlRequest: URLRequest, error: Swift.Error) {
     logNetworkingEvent(
       for: urlRequest,
@@ -29,6 +31,7 @@ extension API {
       complementaryMessage: String(reflecting: error)
     )
   }
+
   internal func logDecodingError(for urlRequest: URLRequest, error: Swift.Error) {
     logNetworkingEvent(
       for: urlRequest,

--- a/Sources/Spyder/API+Public.swift
+++ b/Sources/Spyder/API+Public.swift
@@ -2,6 +2,7 @@ extension API {
   public func addHeader(_ header: Header) {
     persistentHeaders.insert(header)
   }
+
   public var allHeaders: Set<Header> {
     var dynamicHeaders = headersBuilder()
     persistentHeaders.forEach { dynamicHeaders.insert($0) }

--- a/Sources/Spyder/API.swift
+++ b/Sources/Spyder/API.swift
@@ -5,6 +5,7 @@ import FoundationNetworking
 
 public class API<ConstrainedType> {
   public typealias HeadersBuilder = () -> Set<Header>
+  public typealias Object = Sendable & Codable
   public typealias Invoker = (URLRequest) async throws -> HTTPResponse
   public typealias Logger = (_ message: String, _ complementaryMessage: String) -> Void
   public typealias ResponseMiddleware = (API, HTTPResponse) async throws -> HTTPResponse

--- a/Sources/Spyder/API.swift
+++ b/Sources/Spyder/API.swift
@@ -4,10 +4,11 @@ import FoundationNetworking
 #endif
 
 public class API<ConstrainedType> {
+  public typealias Body = Sendable & Encodable
   public typealias HeadersBuilder = () -> Set<Header>
-  public typealias Object = Sendable & Codable
   public typealias Invoker = (URLRequest) async throws -> HTTPResponse
   public typealias Logger = (_ message: String, _ complementaryMessage: String) -> Void
+  public typealias Response = Sendable & Decodable
   public typealias ResponseMiddleware = (API, HTTPResponse) async throws -> HTTPResponse
 
   let baseURLComponents: URLComponents

--- a/Sources/Spyder/Builders/PropertyWrappers.swift
+++ b/Sources/Spyder/Builders/PropertyWrappers.swift
@@ -40,9 +40,9 @@ public struct OptionalQueryArgument: Sendable {
 
 @propertyWrapper
 public struct Body: Sendable {
-  public var wrappedValue: any Encodable
+  public var wrappedValue: API.Object
 
-  public init(wrappedValue: any Encodable) {
+  public init(wrappedValue: API.Object) {
     self.wrappedValue = wrappedValue
   }
 }

--- a/Sources/Spyder/Builders/PropertyWrappers.swift
+++ b/Sources/Spyder/Builders/PropertyWrappers.swift
@@ -40,9 +40,9 @@ public struct OptionalQueryArgument: Sendable {
 
 @propertyWrapper
 public struct Body: Sendable {
-  public var wrappedValue: API.Object
+  public var wrappedValue: API.Body
 
-  public init(wrappedValue: API.Object) {
+  public init(wrappedValue: API.Body) {
     self.wrappedValue = wrappedValue
   }
 }

--- a/Sources/Spyder/Builders/URLRequestBuilder.swift
+++ b/Sources/Spyder/Builders/URLRequestBuilder.swift
@@ -56,17 +56,21 @@ extension URLRequestBuilder {
 private func updateHeaders(_ headers: inout Set<Header>, header: RequestHeader) {
   headers.insert(.init(name: header.name, value: header.wrappedValue))
 }
+
 private func updatePath(from path: String, argument: PathArgument) -> String {
   path.replacingOccurrences(of: "{\(argument.name)}", with: argument.wrappedValue)
 }
+
 private func updateQueryItems(_ queryItems: inout [URLQueryItem], argument: QueryArgument) {
   queryItems.append(URLQueryItem(name: argument.name, value: argument.wrappedValue))
 }
+
 private func updateQueryItems(_ queryItems: inout [URLQueryItem], argument: OptionalQueryArgument) {
   if let wrappedValue = argument.wrappedValue {
     queryItems.append(URLQueryItem(name: argument.name, value: wrappedValue))
   }
 }
+
 private func createBody(from content: Body, using encoder: JSONEncoder) throws -> Data? {
   try encoder.encode(content.wrappedValue)
 }

--- a/Tests/SpyderTests/GitHubAPI.swift
+++ b/Tests/SpyderTests/GitHubAPI.swift
@@ -8,7 +8,7 @@ extension GitHubAPI {
     static var method: HTTPMethod = .get
     static var path: String = "/repositories"
   }
-  struct GetRepositoriesResponse: Decodable, Equatable {
+  struct GetRepositoriesResponse: Codable, Equatable {
     let name: String
   }
 

--- a/Tests/SpyderTests/GitHubAPI.swift
+++ b/Tests/SpyderTests/GitHubAPI.swift
@@ -8,7 +8,7 @@ extension GitHubAPI {
     static var method: HTTPMethod = .get
     static var path: String = "/repositories"
   }
-  struct GetRepositoriesResponse: Codable, Equatable {
+  struct GetRepositoriesResponse: Decodable, Equatable {
     let name: String
   }
 

--- a/Tests/SpyderTests/URLRequestBuilderTests.swift
+++ b/Tests/SpyderTests/URLRequestBuilderTests.swift
@@ -222,7 +222,7 @@ extension URLRequestBuilderTests {
   struct NoQueryNoPathBodyPostRequestExample: URLRequestBuilder {
     static let method: HTTPMethod = .post
     static let path: String = "/api/v1/postRequestExample"
-    @Body var value: any Sendable & Encodable
+    @Body var value: API.Object
     init(value: ContentBody) { self.value = value }
   }
 }

--- a/Tests/SpyderTests/URLRequestBuilderTests.swift
+++ b/Tests/SpyderTests/URLRequestBuilderTests.swift
@@ -222,7 +222,7 @@ extension URLRequestBuilderTests {
   struct NoQueryNoPathBodyPostRequestExample: URLRequestBuilder {
     static let method: HTTPMethod = .post
     static let path: String = "/api/v1/postRequestExample"
-    @Body var value: any Encodable
+    @Body var value: any Sendable & Encodable
     init(value: ContentBody) { self.value = value }
   }
 }

--- a/Tests/SpyderTests/URLRequestBuilderTests.swift
+++ b/Tests/SpyderTests/URLRequestBuilderTests.swift
@@ -222,7 +222,7 @@ extension URLRequestBuilderTests {
   struct NoQueryNoPathBodyPostRequestExample: URLRequestBuilder {
     static let method: HTTPMethod = .post
     static let path: String = "/api/v1/postRequestExample"
-    @Body var value: API.Object
+    @Body var value: API.Body
     init(value: ContentBody) { self.value = value }
   }
 }


### PR DESCRIPTION
- Add Sendable to Output
- Clean with API Object and remove useless Generic
- TODO: See to remove Reflecting. It is fine in debugging and logging like in API+Logging.swift but it should be avoid in production code like in URLRequestBuilder.